### PR TITLE
4.5.0: Vdsm updated to v4.50.0.6

### DIFF
--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -8,7 +8,7 @@ release_date = 2022-05-01
 baseurl = https://github.com/oVirt/
 name = VDSM
 previous = v4.40.100.2
-current = v4.50.0.5
+current = v4.50.0.6
 
 [ovirt-hosted-engine-setup]
 baseurl = https://github.com/oVirt/


### PR DESCRIPTION
As Sandro explained: "That's the only really needed change in order to
build release notes automatically from git log."
