### PR TITLE
4.5.0_alpha1: Added ovirt-imageio-2.4.1-1

### DIFF
--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -155,7 +155,7 @@ current = ovirt-hosted-engine-setup-2.6.1
 [ovirt-imageio]
 name = ovirt-imageio
 previous = v2.3.0
-current = v2.3.0
+current = v2.4.1
 
 [ovirt-jboss-modules-maven-plugin]
 baseurl = https://github.com/oVirt/

--- a/releases/ovirt-4.5.0_alpha1.conf
+++ b/releases/ovirt-4.5.0_alpha1.conf
@@ -1,5 +1,2 @@
 # Builds for oVirt 4.5.0 alpha are delivered via CentOS Virt SIG
 # Adding here only builds that could not be delivered via CentOS.
-
-# ovirt-imageio-2.4.1-1
-https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/centos-stream-8-x86_64/03707433-ovirt-imageio/

--- a/releases/ovirt-4.5.0_alpha1.conf
+++ b/releases/ovirt-4.5.0_alpha1.conf
@@ -1,2 +1,5 @@
 # Builds for oVirt 4.5.0 alpha are delivered via CentOS Virt SIG
 # Adding here only builds that could not be delivered via CentOS.
+
+# ovirt-imageio-2.4.1-1
+https://download.copr.fedorainfracloud.org/results/nsoffer/ovirt-imageio-preview/centos-stream-8-x86_64/03707433-ovirt-imageio/


### PR DESCRIPTION
Since the package is not available in CentOS virt SIG or
ovirt-master-snapshot copr repo I added the package from my
ovirt-imageio-preview repo.

I hope someone can trigger a build in ovirt-master-snapshot, or
add the package to CentOS virt SIG for the next build.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>