### PR TITLE
4.5.0_alpha1: add ovirt-engine-ui-extensions-1.3.1-1

### DIFF
--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -126,7 +126,7 @@ current = 40a956335a121d9d3ee4291d6816996c26acc8ae
 baseurl = https://github.com/oVirt/
 name = oVirt Engine UI Extensions
 previous = ovirt-engine-ui-extensions-1.2.7-1
-current = ovirt-engine-ui-extensions-1.2.7-1
+current = ovirt-engine-ui-extensions-1.3.1-1
 
 [ovirt-engine-wildfly]
 baseurl = https://github.com/oVirt/


### PR DESCRIPTION
The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/03708782-ovirt-engine-ui-extensions/ovirt-engine-ui-extensions-1.3.1-1.el8.noarch.rpm

It is not built on CentOS virt SIG yet.
