### PR TITLE
4.5.0_alpha1: add ovirt-web-ui 1.8.0-1

### DIFF
--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -214,7 +214,7 @@ current = v1.0.9
 baseurl = https://github.com/oVirt/
 name = oVirt Web UI
 previous = 1.7.2
-current = 1.7.2
+current = 1.8.0
 
 [python-ovirt-engine-sdk4]
 baseurl = https://github.com/oVirt/


### PR DESCRIPTION
The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/03710304-ovirt-web-ui/ovirt-web-ui-1.8.0-1.el8.noarch.rpm

It is not built on CentOS virt SIG yet.
