### PR TITLE
pkg_manifest_diff: Increase package name width to 50 characters

### DIFF
--- a/pkg_manifest_diff.py
+++ b/pkg_manifest_diff.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright (C) 2021 Red Hat, Inc.
+# Copyright (C) 2021-2022 Red Hat, Inc.
 # Author: Lev Veyde <lveyde@redhat.com>
 #
 # This program is free software; you can redistribute it and/or modify
@@ -36,7 +36,7 @@ appliance_baseurl = ('https://jenkins.ovirt.org/job/ovirt-appliance_master_'
                      'exported-artifacts/'
                      'ovirt-engine-appliance-manifest-rpm')
 
-pkg_name_width = 40
+pkg_name_width = 50
 pkg_ver_width = 40
 
 


### PR DESCRIPTION
Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Increased package name width to 50 characters, to account for longer package names

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]