### PR TITLE
pkg_manifest_diff: Updated the package name width option default

### DIFF
--- a/pkg_manifest_diff.py
+++ b/pkg_manifest_diff.py
@@ -346,8 +346,8 @@ def main():
     parser.add_argument(
         '--name-width',
         type=int,
-        default=40,
-        help='package name column width. default=40'
+        default=50,
+        help='package name column width. default=50'
     )
     parser.add_argument(
         '--version-width',


### PR DESCRIPTION
Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Updated package name width option default to 50 character as well

#  Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]