### PR TITLE
pkg_manifest_diff: Modified file reading code for Python3

### DIFF
--- a/pkg_manifest_diff.py
+++ b/pkg_manifest_diff.py
@@ -299,8 +299,8 @@ def compare(package_list1, package_list2):
 
 def process_build_arg(arg, type):
     if os.path.isfile(os.path.abspath(arg)):
-        with open(os.path.abspath(arg)) as f:
-            build_list = f.readlines().decode("utf-8")
+        with open(os.path.abspath(arg), encoding='utf-8') as f:
+            build_list = f.read().splitlines()
     else:
         if type == 'appliance':
             url = appliance_baseurl.format(arg)


### PR DESCRIPTION
Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Fix file reading code, that is used for a local manifest, to work for Python3.
 
## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]