### PR TITLE
4.5.0: add ovirt-engine-nodejs-modules-2.2.3-1

### DIFF
--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -121,7 +121,7 @@ current = ovirt-engine-metrics-1.5.0
 baseurl = https://github.com/oVirt/
 name = oVirt Engine NodeJS Modules
 previous = f386c5a42026320999978b10023150e9b5961c4b
-current = 40a956335a121d9d3ee4291d6816996c26acc8ae
+current = c1b82a87a263064bfad0c8d2db6336c8630d2852
 
 [ovirt-engine-ui-extensions]
 baseurl = https://github.com/oVirt/


### PR DESCRIPTION
add ovirt-engine-nodejs-modules-2.2.3-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/03911445-ovirt-engine-nodejs-modules/