### PR TITLE
4.5.0: add ovirt-engine-ui-extensions-1.3.2-1

### DIFF
--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -127,7 +127,7 @@ current = 40a956335a121d9d3ee4291d6816996c26acc8ae
 baseurl = https://github.com/oVirt/
 name = oVirt Engine UI Extensions
 previous = ovirt-engine-ui-extensions-1.2.7-1
-current = ovirt-engine-ui-extensions-1.3.1-1
+current = ovirt-engine-ui-extensions-1.3.2-1
 
 [ovirt-engine-wildfly]
 baseurl = https://github.com/oVirt/


### PR DESCRIPTION
add ovirt-engine-ui-extensions-1.3.2-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/03912037-ovirt-engine-ui-extensions/