### PR TITLE
4.5.0: add ovirt-web-ui 1.8.1-1

### DIFF
--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -217,7 +217,7 @@ current = v1.0.9
 baseurl = https://github.com/oVirt/
 name = oVirt Web UI
 previous = 1.7.2
-current = 1.8.0
+current = 1.8.1
 
 [python-ovirt-engine-sdk4]
 baseurl = https://github.com/oVirt/


### PR DESCRIPTION
Add ovirt-web-ui 1.8.1-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/03912530-ovirt-web-ui/