### PR TITLE
4.5.0: add ovirt-engine-dwh-4.5.2

### DIFF
--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -80,7 +80,7 @@ current = ovirt-engine-4.5.0
 baseurl = https://github.com/oVirt/
 name = oVirt Engine Data Warehouse
 previous = ovirt-engine-dwh-4.4.10
-current = ovirt-engine-dwh-4.5.1
+current = ovirt-engine-dwh-4.5.2
 
 [ovirt-engine-extension-aaa-jdbc]
 baseurl = https://github.com/oVirt/


### PR DESCRIPTION
Update ovirt-engine-dwh current version to 4.5.2 in /milestones/ovirt-4.5.0.conf 

Signed-off-by: Aviv Litman <alitman@redhat.com>
