### PR TITLE
4.5.0: add ovirt-engine-metrics-1.6.0

### DIFF
--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -114,8 +114,8 @@ current = 7964f576a50cf9ef72453503c20161b202f03246
 [ovirt-engine-metrics]
 baseurl = https://github.com/oVirt/
 name = oVirt Engine Metrics
-previous = ovirt-engine-metrics-1.4.4
-current = ovirt-engine-metrics-1.5.0
+previous = ovirt-engine-metrics-1.5.0
+current = ovirt-engine-metrics-1.6.0
 
 [ovirt-engine-nodejs-modules]
 baseurl = https://github.com/oVirt/

--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -114,7 +114,7 @@ current = 7964f576a50cf9ef72453503c20161b202f03246
 [ovirt-engine-metrics]
 baseurl = https://github.com/oVirt/
 name = oVirt Engine Metrics
-previous = ovirt-engine-metrics-1.5.0
+previous = ovirt-engine-metrics-1.4.4
 current = ovirt-engine-metrics-1.6.0
 
 [ovirt-engine-nodejs-modules]


### PR DESCRIPTION
Update ovirt-engine-metrics current version to 1.6.0 in /milestones/ovirt-4.5.0.conf