### PR TITLE
4.5.0: add ovirt-engine-ui-extensions-1.3.3-1

### DIFF
--- a/milestones/ovirt-4.5.0.conf
+++ b/milestones/ovirt-4.5.0.conf
@@ -121,7 +121,7 @@ current = c1b82a87a263064bfad0c8d2db6336c8630d2852
 baseurl = https://github.com/oVirt/
 name = oVirt Engine UI Extensions
 previous = ovirt-engine-ui-extensions-1.2.7-1
-current = ovirt-engine-ui-extensions-1.3.2-1
+current = ovirt-engine-ui-extensions-1.3.3-1
 
 [ovirt-engine-wildfly]
 baseurl = https://github.com/oVirt/


### PR DESCRIPTION
add ovirt-engine-ui-extensions-1.3.3-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/04335111-ovirt-engine-ui-extensions/
