### PR TITLE
4.5.1: add ovirt-engine-nodejs-modules-2.3.2-2

### DIFF
--- a/milestones/ovirt-4.5.1.conf
+++ b/milestones/ovirt-4.5.1.conf
@@ -44,3 +44,9 @@ baseurl = https://github.com/oVirt/
 name = ovirt-imageio
 previous = v2.4.3
 current = v2.4.5
+
+[ovirt-engine-nodejs-modules]
+baseurl = https://github.com/oVirt/
+name = oVirt Engine NodeJS Modules
+previous = c1b82a87a263064bfad0c8d2db6336c8630d2852
+current = 894ae02619a7aa968dc987e2771dc5ec6964aeba


### PR DESCRIPTION
add ovirt-engine-nodejs-modules-2.3.2-2

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/04507561-ovirt-engine-nodejs-modules/
