### PR TITLE
4.5.1: add ovirt-engine-ui-extensions-1.3.4-1

### DIFF
--- a/milestones/ovirt-4.5.1.conf
+++ b/milestones/ovirt-4.5.1.conf
@@ -50,3 +50,9 @@ baseurl = https://github.com/oVirt/
 name = oVirt Engine NodeJS Modules
 previous = c1b82a87a263064bfad0c8d2db6336c8630d2852
 current = 894ae02619a7aa968dc987e2771dc5ec6964aeba
+
+[ovirt-engine-ui-extensions]
+baseurl = https://github.com/oVirt/
+name = oVirt Engine UI Extensions
+previous = ovirt-engine-ui-extensions-1.3.3-1
+current = ovirt-engine-ui-extensions-1.3.4-1


### PR DESCRIPTION
add ovirt-engine-ui-extensions-1.3.4-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/04536774-ovirt-engine-ui-extensions/
