### PR TITLE
4.5.2: add ovirt-engine-nodejs-modules-2.3.8-1

### DIFF
--- a/milestones/ovirt-4.5.2.conf
+++ b/milestones/ovirt-4.5.2.conf
@@ -14,17 +14,11 @@ baseurl = https://github.com/oVirt/
 name = oVirt Engine NodeJS Modules
 # ovirt-engine-nodejs-modules-2.3.2-2
 previous = 894ae02619a7aa968dc987e2771dc5ec6964aeba
-# ovirt-engine-nodejs-modules-2.3.5-1
-current = e0b688bfe512699178d85110134e590bc8f4df49
+# ovirt-engine-nodejs-modules-2.3.8-1
+current = d2fd0c40d49c5a22b899f4ebe854b3b67d006b5d
 
 [cockpit-ovirt]
 baseurl = https://github.com/oVirt/
 name = oVirt Cockpit Plugin
 previous = cockpit-ovirt-0.16.0
 current = cockpit-ovirt-0.16.1
-
-[ovirt-engine-nodejs-modules]
-baseurl = https://github.com/oVirt/
-name = oVirt Engine NodeJS Modules
-previous = 894ae02619a7aa968dc987e2771dc5ec6964aeba
-current = d2fd0c40d49c5a22b899f4ebe854b3b67d006b5d

--- a/milestones/ovirt-4.5.2.conf
+++ b/milestones/ovirt-4.5.2.conf
@@ -22,3 +22,9 @@ baseurl = https://github.com/oVirt/
 name = oVirt Cockpit Plugin
 previous = cockpit-ovirt-0.16.0
 current = cockpit-ovirt-0.16.1
+
+[ovirt-engine-nodejs-modules]
+baseurl = https://github.com/oVirt/
+name = oVirt Engine NodeJS Modules
+previous = 894ae02619a7aa968dc987e2771dc5ec6964aeba
+current = d2fd0c40d49c5a22b899f4ebe854b3b67d006b5d


### PR DESCRIPTION
add ovirt-engine-nodejs-modules-2.3.8-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/04661781-ovirt-engine-nodejs-modules/