### PR TITLE
4.5.2: add ovirt-engine-ui-extensions-1.3.5-1

### DIFF
--- a/milestones/ovirt-4.5.2.conf
+++ b/milestones/ovirt-4.5.2.conf
@@ -28,3 +28,9 @@ baseurl = https://github.com/oVirt/
 name = MOM
 previous = v0.6.2
 current = v0.6.3
+
+[ovirt-engine-ui-extensions]
+baseurl = https://github.com/oVirt/
+name = oVirt Engine UI Extensions
+previous = ovirt-engine-ui-extensions-1.3.4-1
+current = ovirt-engine-ui-extensions-1.3.5-1


### PR DESCRIPTION
add ovirt-engine-ui-extensions-1.3.5-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/04662238-ovirt-engine-ui-extensions/
