### PR TITLE
4.5.2: add ovirt-engine-nodejs-modules-2.3.9-1

### DIFF
--- a/milestones/ovirt-4.5.2.conf
+++ b/milestones/ovirt-4.5.2.conf
@@ -14,8 +14,8 @@ baseurl = https://github.com/oVirt/
 name = oVirt Engine NodeJS Modules
 # ovirt-engine-nodejs-modules-2.3.2-2
 previous = 894ae02619a7aa968dc987e2771dc5ec6964aeba
-# ovirt-engine-nodejs-modules-2.3.8-1
-current = 46dbbaacb703fbf704669cf930c88de217636a8b
+# ovirt-engine-nodejs-modules-2.3.9-1
+current = 243a9ea4191031f9554de14b02d19908f0fdc793
 
 [cockpit-ovirt]
 baseurl = https://github.com/oVirt/


### PR DESCRIPTION
add ovirt-engine-nodejs-modules-2.3.9-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/04705048-ovirt-engine-nodejs-modules/
