### PR TITLE
4.5.2: Updated ovirt-engine to 4.5.2.5

### DIFF
--- a/milestones/ovirt-4.5.2.conf
+++ b/milestones/ovirt-4.5.2.conf
@@ -63,7 +63,7 @@ current = v1.7.2
 baseurl = https://github.com/oVirt/
 name = oVirt Engine
 previous = ovirt-engine-4.5.1.3
-current = ovirt-engine-4.5.2.1
+current = ovirt-engine-4.5.2.5
 
 [ovirt-imageio]
 baseurl = https://github.com/oVirt/
@@ -74,7 +74,7 @@ current = v2.4.6
 [ovirt-dwh]
 baseurl = https://github.com/oVirt/
 name = oVirt Engine Data Warehouse
-previous = ovirt-engine-dwh-4.5.4
+previous = ovirt-engine-dwh-4.5.3
 current = ovirt-engine-dwh-4.5.5
 
 [python-ovirt-engine-sdk4]


### PR DESCRIPTION
Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Updated ovirt-engine version to 4.5.2.5
* Restored the previous version of ovirt-engine-dwh to 4.5.3

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]