### PR TITLE
4.5.3: add ovirt-engine-ui-extensions-1.3.6-1

### DIFF
--- a/milestones/ovirt-4.5.3.conf
+++ b/milestones/ovirt-4.5.3.conf
@@ -3,3 +3,9 @@ baseurl = https://github.com/oVirt/
 name = VDSM
 previous = v4.50.2.2
 current = v4.50.3
+
+[ovirt-engine-ui-extensions]
+baseurl = https://github.com/oVirt/
+name = oVirt Engine UI Extensions
+previous = ovirt-engine-ui-extensions-1.3.5-1
+current = ovirt-engine-ui-extensions-1.3.6-1


### PR DESCRIPTION

add ovirt-engine-ui-extensions-1.3.6-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/04877688-ovirt-engine-ui-extensions/
