### PR TITLE
4.5.3: add ovirt-engine-nodejs-modules-2.3.10-1

### DIFF
--- a/milestones/ovirt-4.5.3.conf
+++ b/milestones/ovirt-4.5.3.conf
@@ -9,3 +9,11 @@ baseurl = https://github.com/oVirt/
 name = oVirt Engine UI Extensions
 previous = ovirt-engine-ui-extensions-1.3.5-1
 current = ovirt-engine-ui-extensions-1.3.6-1
+
+[ovirt-engine-nodejs-modules]
+baseurl = https://github.com/oVirt/
+name = oVirt Engine NodeJS Modules
+# ovirt-engine-nodejs-modules-2.3.9-1
+previous = 243a9ea4191031f9554de14b02d19908f0fdc793
+# ovirt-engine-nodejs-modules-2.3.10-1
+current = caafa9fdbdd82a677778cd0504695946eac37f61


### PR DESCRIPTION
add ovirt-engine-nodejs-modules-2.3.10-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/04878260-ovirt-engine-nodejs-modules/
