### PR TITLE
4.5.3: add ovirt-web-ui 1.9.2-1

### DIFF
--- a/milestones/ovirt-4.5.3.conf
+++ b/milestones/ovirt-4.5.3.conf
@@ -9,3 +9,9 @@ baseurl = https://github.com/oVirt/
 name = oVirt Engine UI Extensions
 previous = ovirt-engine-ui-extensions-1.3.5-1
 current = ovirt-engine-ui-extensions-1.3.6-1
+
+[ovirt-web-ui]
+baseurl = https://github.com/oVirt/
+name = oVirt Web UI
+previous = 1.9.1
+current = 1.9.2


### PR DESCRIPTION
Add ovirt-web-ui 1.9.2-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/04882100-ovirt-web-ui/
