### PR TITLE
4.5.3: fix ovirt-release previous version

### DIFF
--- a/milestones/ovirt-4.5.3.conf
+++ b/milestones/ovirt-4.5.3.conf
@@ -87,5 +87,5 @@ current = ovirt-hosted-engine-setup-2.6.6
 [ovirt-release]
 baseurl = https://github.com/oVirt/
 name = oVirt Release Host Node
-previous = ovirt-release-host-node-4.5.3-1
+previous = ovirt-release-host-node-4.5.2-1
 current = ovirt-release-host-node-4.5.3.2-1


### PR DESCRIPTION
## Changes introduced with this PR

* Fixes:
```
ovirt-release has previous set to ovirt-release-host-node-4.5.3-1
while last known is ovirt-release-host-node-4.5.2-1
```

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>
## Are you the owner of the code you are sending in, or do you have permission of the owner?

y