### PR TITLE
4.5.4: Re-added ovirt-imageio-2.4.7

### DIFF
--- a/milestones/ovirt-4.5.4.conf
+++ b/milestones/ovirt-4.5.4.conf
@@ -16,13 +16,11 @@ name = oVirt Ansible Collection
 previous = 2.4.0-1
 current = 3.0.0-1
 
-# [ovirt-imageio]
-# baseurl = https://github.com/oVirt/
-# name = ovirt-imageio
-# previous = v2.4.6
-# current = v2.4.7
-# v2.4.7 tag is broken
-
+[ovirt-imageio]
+baseurl = https://github.com/oVirt/
+name = ovirt-imageio
+previous = v2.4.6
+current = v2.4.7
 
 [ovirt-engine]
 baseurl = https://github.com/oVirt/


### PR DESCRIPTION
Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Re-added bump of ovirt-imageio to v2.4.7 as the tag issue was fixed

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]