### PR TITLE
4.5.5: add ovirt-engine-nodejs-modules-2.3.20-1

### DIFF
--- a/milestones/ovirt-4.5.5.conf
+++ b/milestones/ovirt-4.5.5.conf
@@ -1,0 +1,8 @@
+[ovirt-engine-nodejs-modules]
+baseurl = https://github.com/oVirt/
+name = oVirt Engine NodeJS Modules
+# ovirt-engine-nodejs-modules-2.3.10-1
+previous = caafa9fdbdd82a677778cd0504695946eac37f61
+# ovirt-engine-nodejs-modules-2.3.20-1
+current = e788699489681858609092283f165e0fef766ef8
+


### PR DESCRIPTION
add ovirt-engine-nodejs-modules-2.3.20-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/05147221-ovirt-engine-nodejs-modules/
