### PR TITLE
4.5.5: add ovirt-engine-ui-extensions-1.3.7-1

### DIFF
--- a/milestones/ovirt-4.5.5.conf
+++ b/milestones/ovirt-4.5.5.conf
@@ -1,0 +1,5 @@
+[ovirt-engine-ui-extensions]
+baseurl = https://github.com/oVirt/
+name = oVirt Engine UI Extensions
+previous = ovirt-engine-ui-extensions-1.3.6-1
+current = ovirt-engine-ui-extensions-1.3.7-1


### PR DESCRIPTION
add ovirt-engine-ui-extensions-1.3.7-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/05153080-ovirt-engine-ui-extensions/
