### PR TITLE
4.5.5: add ovirt-web-ui 1.9.3-1

### DIFF
--- a/milestones/ovirt-4.5.5.conf
+++ b/milestones/ovirt-4.5.5.conf
@@ -11,3 +11,9 @@ name = oVirt Engine NodeJS Modules
 previous = caafa9fdbdd82a677778cd0504695946eac37f61
 # ovirt-engine-nodejs-modules-2.3.20-1
 current = e788699489681858609092283f165e0fef766ef8
+
+[ovirt-web-ui]
+baseurl = https://github.com/oVirt/
+name = oVirt Web UI
+previous = 1.9.2
+current = 1.9.3


### PR DESCRIPTION
Add ovirt-web-ui 1.9.3-1

The package is available on ovirt-master-snapshot copr repo:
https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/05154411-ovirt-web-ui/